### PR TITLE
Add self-hosted GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: [self-hosted, macos]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26'
+      - name: Run tests
+        run: |
+          xcodebuild -project apex/apex.xcodeproj \
+            -scheme apex \
+            -destination 'platform=iOS Simulator,name=iPhone 14' \
+            test


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow for a macOS self‑hosted runner with Xcode 26

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d086ca0fc832a93d9ae6e63649e8f