### PR TITLE
Fix CI config for available Xcode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16'
+          xcode-version: '16.4'
       - name: Run tests
         run: |
-          xcodebuild -project apex/apex.xcodeproj \
-            -scheme apex \
-            -destination 'platform=iOS Simulator,name=iPhone 14' \
-            test
+            xcodebuild -project apex/apex.xcodeproj \
+              -scheme apex \
+              -destination 'platform=iOS Simulator,name=iPhone 16' \
+              test


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to use Xcode 16.4
- select a simulator that actually exists (`iPhone 16`)

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild ... test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0b20b580832ab026c71657653b50