### PR TITLE
Add Liquid Glass TabView

### DIFF
--- a/apex/apex/MainTabView.swift
+++ b/apex/apex/MainTabView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            Text("Home")
+                .tabItem {
+                    Image(systemName: "house")
+                    Text("Home")
+                }
+                .accessibilityLabel("Home tab")
+
+            Text("Log")
+                .tabItem {
+                    Image(systemName: "plus.circle")
+                    Text("Log")
+                }
+                .accessibilityLabel("Log tab")
+
+            Text("Progress")
+                .tabItem {
+                    Image(systemName: "chart.bar")
+                    Text("Progress")
+                }
+                .accessibilityLabel("Progress tab")
+
+            Text("Coach")
+                .tabItem {
+                    Image(systemName: "message")
+                    Text("Coach")
+                }
+                .accessibilityLabel("Coach tab")
+
+            ContentView()
+                .tabItem {
+                    Image(systemName: "person.circle")
+                    Text("Profile")
+                }
+                .accessibilityLabel("Profile tab")
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+        .environment(\.managedObjectContext, CoreDataStack.shared.context)
+}

--- a/apex/apex/MainTabView.swift
+++ b/apex/apex/MainTabView.swift
@@ -31,7 +31,7 @@ struct MainTabView: View {
                 }
                 .accessibilityLabel("Coach tab")
 
-            ContentView()
+            Text("Profile")
                 .tabItem {
                     Image(systemName: "person.circle")
                     Text("Profile")

--- a/apex/apex/apexApp.swift
+++ b/apex/apex/apexApp.swift
@@ -14,7 +14,7 @@ struct apexApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            MainTabView()
                 .environment(\.managedObjectContext, stack.context)
         }
     }


### PR DESCRIPTION
## Summary
- add a new `MainTabView` with 5 placeholder tabs
- use SF Symbols for Home, Log, Progress, Coach, and Profile tabs
- make `MainTabView` the app root

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d0cec6b28832ab907ee0c20062b46