### PR TITLE
Implement multi-step onboarding

### DIFF
--- a/apex/apex/CoreData/CoreDataStack.swift
+++ b/apex/apex/CoreData/CoreDataStack.swift
@@ -24,7 +24,15 @@ class CoreDataStack {
             attribute(name: "age", type: .integer16AttributeType),
             attribute(name: "weight", type: .doubleAttributeType),
             attribute(name: "height", type: .doubleAttributeType),
-            attribute(name: "joinDate", type: .dateAttributeType)
+            attribute(name: "joinDate", type: .dateAttributeType),
+            attribute(name: "gender", type: .stringAttributeType, optional: true),
+            attribute(name: "goal", type: .stringAttributeType, optional: true),
+            attribute(name: "activityLevel", type: .stringAttributeType, optional: true),
+            attribute(name: "dietaryPreferences", type: .stringAttributeType, optional: true),
+            attribute(name: "usesGLP1", type: .booleanAttributeType),
+            attribute(name: "coachPersonality", type: .stringAttributeType, optional: true),
+            attribute(name: "onboardingStep", type: .integer16AttributeType),
+            attribute(name: "hasCompletedOnboarding", type: .booleanAttributeType)
         ]
 
         let food = NSEntityDescription()

--- a/apex/apex/CoreData/UserProfile.swift
+++ b/apex/apex/CoreData/UserProfile.swift
@@ -9,6 +9,14 @@ public class UserProfile: NSManagedObject {
     @NSManaged public var weight: Double
     @NSManaged public var height: Double
     @NSManaged public var joinDate: Date
+    @NSManaged public var gender: String?
+    @NSManaged public var goal: String?
+    @NSManaged public var activityLevel: String?
+    @NSManaged public var dietaryPreferences: String?
+    @NSManaged public var usesGLP1: Bool
+    @NSManaged public var coachPersonality: String?
+    @NSManaged public var onboardingStep: Int16
+    @NSManaged public var hasCompletedOnboarding: Bool
 }
 
 extension UserProfile {

--- a/apex/apex/ViewModels/OnboardingCoordinator.swift
+++ b/apex/apex/ViewModels/OnboardingCoordinator.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import Combine
+import CoreData
+
+class OnboardingCoordinator: ObservableObject {
+    enum Step: Int, CaseIterable {
+        case age, gender, height, weight, goal, activity, dietaryPrefs, glp1, coachPersonality
+    }
+
+    @Published var step: Step
+    @Published var age: String = ""
+    @Published var gender: String = ""
+    @Published var height: String = ""
+    @Published var weight: String = ""
+    @Published var goal: String = ""
+    @Published var activityLevel: String = ""
+    @Published var dietaryPrefs: String = ""
+    @Published var usesGLP1: Bool = false
+    @Published var coachPersonality: String = ""
+    @Published var error: String?
+
+    @AppStorage("onboardingStep") private var savedStep: Int = 0
+    @AppStorage("hasCompletedOnboarding") private var hasCompleted: Bool = false
+
+    private let stack: CoreDataStack
+
+    init(stack: CoreDataStack = .shared) {
+        self.stack = stack
+        step = Step(rawValue: savedStep) ?? .age
+    }
+
+    func next() {
+        guard validateCurrentStep() else { return }
+        if step == .coachPersonality {
+            completeOnboarding()
+            return
+        }
+        step = Step(rawValue: step.rawValue + 1) ?? .age
+        savedStep = step.rawValue
+        error = nil
+    }
+
+    func back() {
+        guard step.rawValue > 0 else { return }
+        step = Step(rawValue: step.rawValue - 1) ?? .age
+        savedStep = step.rawValue
+        error = nil
+    }
+
+    private func validateCurrentStep() -> Bool {
+        switch step {
+        case .age:
+            guard Int(age) != nil else { error = "Enter a valid age"; return false }
+        case .gender:
+            guard !gender.isEmpty else { error = "Select a gender"; return false }
+        case .height:
+            guard Double(height) != nil else { error = "Enter height"; return false }
+        case .weight:
+            guard Double(weight) != nil else { error = "Enter weight"; return false }
+        case .goal:
+            guard !goal.isEmpty else { error = "Enter a goal"; return false }
+        case .activity:
+            guard !activityLevel.isEmpty else { error = "Enter activity level"; return false }
+        case .dietaryPrefs:
+            guard !dietaryPrefs.isEmpty else { error = "Enter dietary preference"; return false }
+        case .glp1:
+            break
+        case .coachPersonality:
+            guard !coachPersonality.isEmpty else { error = "Choose a coach style"; return false }
+        }
+        return true
+    }
+
+    private func completeOnboarding() {
+        let context = stack.context
+        let profile = UserProfile(context: context)
+        profile.id = UUID()
+        profile.name = "User"
+        profile.age = Int16(Int(age) ?? 0)
+        profile.weight = Double(weight) ?? 0
+        profile.height = Double(height) ?? 0
+        profile.joinDate = Date()
+        profile.gender = gender
+        profile.goal = goal
+        profile.activityLevel = activityLevel
+        profile.dietaryPreferences = dietaryPrefs
+        profile.usesGLP1 = usesGLP1
+        profile.coachPersonality = coachPersonality
+        profile.hasCompletedOnboarding = true
+        profile.onboardingStep = Int16(Step.coachPersonality.rawValue)
+        do {
+            try stack.saveContext()
+            hasCompleted = true
+            savedStep = 0
+        } catch {
+            self.error = "Failed to save profile"
+        }
+    }
+}

--- a/apex/apex/Views/OnboardingView.swift
+++ b/apex/apex/Views/OnboardingView.swift
@@ -1,0 +1,255 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @StateObject private var coordinator = OnboardingCoordinator()
+
+    var body: some View {
+        VStack {
+            switch coordinator.step {
+            case .age:
+                AgeStepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .gender:
+                GenderStepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .height:
+                HeightStepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .weight:
+                WeightStepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .goal:
+                GoalStepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .activity:
+                ActivityStepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .dietaryPrefs:
+                DietaryStepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .glp1:
+                GLP1StepView(coordinator: coordinator)
+                    .transition(.slide)
+            case .coachPersonality:
+                CoachPersonalityStepView(coordinator: coordinator)
+                    .transition(.slide)
+            }
+        }
+        .animation(.easeInOut, value: coordinator.step)
+        .padding()
+    }
+}
+
+private struct AgeStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("What's your age?")
+                .font(.title)
+            TextField("Age", text: $coordinator.age)
+                .keyboardType(.numberPad)
+                .textFieldStyle(.roundedBorder)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct GenderStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Select your gender")
+                .font(.title)
+            Picker("Gender", selection: $coordinator.gender) {
+                Text("Male").tag("Male")
+                Text("Female").tag("Female")
+                Text("Other").tag("Other")
+            }
+            .pickerStyle(.segmented)
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct HeightStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Enter your height (cm)")
+                .font(.title)
+            TextField("Height", text: $coordinator.height)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(.roundedBorder)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct WeightStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Enter your weight (kg)")
+                .font(.title)
+            TextField("Weight", text: $coordinator.weight)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(.roundedBorder)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct GoalStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("What's your primary goal?")
+                .font(.title)
+            TextField("Goal", text: $coordinator.goal)
+                .textFieldStyle(.roundedBorder)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct ActivityStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Describe your activity level")
+                .font(.title)
+            TextField("Activity Level", text: $coordinator.activityLevel)
+                .textFieldStyle(.roundedBorder)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct DietaryStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Dietary preferences")
+                .font(.title)
+            TextField("Dietary Preferences", text: $coordinator.dietaryPrefs)
+                .textFieldStyle(.roundedBorder)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct GLP1StepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Toggle("Are you using GLP-1 medication?", isOn: $coordinator.usesGLP1)
+                .toggleStyle(.switch)
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Next") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct CoachPersonalityStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Preferred coach personality")
+                .font(.title)
+            Picker("Coach Style", selection: $coordinator.coachPersonality) {
+                Text("Encouraging").tag("Encouraging")
+                Text("Tough Love").tag("ToughLove")
+                Text("Balanced").tag("Balanced")
+            }
+            .pickerStyle(.segmented)
+            if let error = coordinator.error {
+                Text(error).foregroundColor(.red)
+            }
+            HStack {
+                Button("Back") { coordinator.back() }
+                Spacer()
+                Button("Finish") { coordinator.next() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+#Preview {
+    OnboardingView()
+        .environment(\.managedObjectContext, CoreDataStack.shared.context)
+}

--- a/apex/apex/apexApp.swift
+++ b/apex/apex/apexApp.swift
@@ -11,11 +11,17 @@ import CoreData
 @main
 struct apexApp: App {
     private let stack = CoreDataStack.shared
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     var body: some Scene {
         WindowGroup {
-            HomeView()
-                .environment(\.managedObjectContext, stack.context)
+            if hasCompletedOnboarding {
+                HomeView()
+                    .environment(\.managedObjectContext, stack.context)
+            } else {
+                OnboardingView()
+                    .environment(\.managedObjectContext, stack.context)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- support additional onboarding fields in `UserProfile` and Core Data model
- drive onboarding progress with new `OnboardingCoordinator`
- create `OnboardingView` with one screen per onboarding step
- show onboarding screens before `HomeView` until completed

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d0dace688832ab69bc78914feb054