### PR TITLE
Add HealthKit service and sync settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains the Apex sample iOS application. The project is a simpl
 
 ## Capabilities
 - **iCloud / CloudKit** for data syncing
-- **HealthKit** to access workout data
+- **HealthKit** to access steps, workouts, sleep, and hydration data
 - **SiriKit** so you can start workouts with your voice
 - **Authentication** with Sign in with Apple, email magic link, and guest mode
 

--- a/apex/apex/ContentView.swift
+++ b/apex/apex/ContentView.swift
@@ -52,6 +52,7 @@ struct ContentView: View {
             profile.height = 0
             profile.joinDate = Date()
             profile.accountType = "guest"
+            profile.syncHealthKit = false
             try? moc.save()
         }
     }

--- a/apex/apex/CoreData/CoreDataStack.swift
+++ b/apex/apex/CoreData/CoreDataStack.swift
@@ -36,7 +36,8 @@ class CoreDataStack {
             attribute(name: "coachPersonality", type: .stringAttributeType, optional: true),
             attribute(name: "onboardingStep", type: .integer16AttributeType),
             attribute(name: "hasCompletedOnboarding", type: .booleanAttributeType),
-            attribute(name: "accountType", type: .stringAttributeType, optional: true)
+            attribute(name: "accountType", type: .stringAttributeType, optional: true),
+            attribute(name: "syncHealthKit", type: .booleanAttributeType)
         ]
 
         let food = NSEntityDescription()

--- a/apex/apex/CoreData/UserProfile.swift
+++ b/apex/apex/CoreData/UserProfile.swift
@@ -21,6 +21,7 @@ public class UserProfile: NSManagedObject {
     @NSManaged public var onboardingStep: Int16
     @NSManaged public var hasCompletedOnboarding: Bool
     @NSManaged public var accountType: String?
+    @NSManaged public var syncHealthKit: Bool
 }
 
 extension UserProfile {
@@ -43,7 +44,8 @@ extension UserProfile {
             usesGLP1: usesGLP1,
             dietaryPreferences: dietaryPreferences ?? "",
             coachType: coachPersonality ?? "",
-            accountType: accountType ?? "guest"
+            accountType: accountType ?? "guest",
+            syncHealthKit: syncHealthKit
         )
     }
 
@@ -62,6 +64,7 @@ extension UserProfile {
         dietaryPreferences = model.dietaryPreferences
         coachPersonality = model.coachType
         accountType = model.accountType
+        syncHealthKit = model.syncHealthKit
     }
 }
 extension UserProfile: Identifiable {}

--- a/apex/apex/Models/UserProfileModel.swift
+++ b/apex/apex/Models/UserProfileModel.swift
@@ -16,6 +16,7 @@ struct UserProfileModel: Identifiable, Codable {
     var dietaryPreferences: String
     var coachType: String
     var accountType: String // guest or full
+    var syncHealthKit: Bool
 }
 
 extension UserProfileModel {
@@ -36,6 +37,7 @@ extension UserProfileModel {
         self.dietaryPreferences = ""
         self.coachType = ""
         self.accountType = "guest"
+        self.syncHealthKit = false
     }
 
     init?(record: CKRecord) {
@@ -53,6 +55,7 @@ extension UserProfileModel {
             let coachType = record["coachType"] as? String,
             let accountType = record["accountType"] as? String
         else { return nil }
+        let syncHealthKit = record["syncHealthKit"] as? Int ?? 0
 
         self.id = UUID(uuidString: record.recordID.recordName) ?? UUID()
         self.name = name
@@ -68,6 +71,7 @@ extension UserProfileModel {
         self.dietaryPreferences = dietaryPreferences
         self.coachType = coachType
         self.accountType = accountType
+        self.syncHealthKit = syncHealthKit == 1
     }
 
     func toRecord() -> CKRecord {
@@ -88,6 +92,7 @@ extension UserProfileModel {
         record["dietaryPreferences"] = dietaryPreferences as CKRecordValue
         record["coachType"] = coachType as CKRecordValue
         record["accountType"] = accountType as CKRecordValue
+        record["syncHealthKit"] = (syncHealthKit ? 1 : 0) as CKRecordValue
         return record
     }
 }

--- a/apex/apex/Services/HealthKitService.swift
+++ b/apex/apex/Services/HealthKitService.swift
@@ -1,0 +1,129 @@
+import Foundation
+import HealthKit
+import Combine
+
+class HealthKitService: ObservableObject {
+    static let shared = HealthKitService()
+
+    private let store = HKHealthStore()
+    private var queries: [HKObserverQuery] = []
+
+    @Published var stepsToday: Double = 0
+    @Published var workouts: [HKWorkout] = []
+    @Published var sleep: [HKCategorySample] = []
+    @Published var hydration: Double = 0
+    @Published var isAuthorized: Bool = false
+
+    func requestAuthorization() {
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+        var readTypes = Set<HKObjectType>()
+        if let steps = HKObjectType.quantityType(forIdentifier: .stepCount) {
+            readTypes.insert(steps)
+        }
+        if let sleep = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) {
+            readTypes.insert(sleep)
+        }
+        if let water = HKObjectType.quantityType(forIdentifier: .dietaryWater) {
+            readTypes.insert(water)
+        }
+        readTypes.insert(HKObjectType.workoutType())
+
+        store.requestAuthorization(toShare: nil, read: readTypes) { success, _ in
+            DispatchQueue.main.async {
+                self.isAuthorized = success
+                if success {
+                    self.startObservers()
+                    self.fetchAll()
+                }
+            }
+        }
+    }
+
+    func fetchAll() {
+        fetchSteps()
+        fetchWorkouts()
+        fetchSleep()
+        fetchHydration()
+    }
+
+    private func startObservers() {
+        queries.forEach { store.stop($0) }
+        queries.removeAll()
+
+        if let stepsType = HKObjectType.quantityType(forIdentifier: .stepCount) {
+            let query = HKObserverQuery(sampleType: stepsType, predicate: nil) { [weak self] _, completion, _ in
+                self?.fetchSteps()
+                completion()
+            }
+            store.execute(query)
+            queries.append(query)
+        }
+        if let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) {
+            let query = HKObserverQuery(sampleType: sleepType, predicate: nil) { [weak self] _, completion, _ in
+                self?.fetchSleep()
+                completion()
+            }
+            store.execute(query)
+            queries.append(query)
+        }
+        if let waterType = HKObjectType.quantityType(forIdentifier: .dietaryWater) {
+            let query = HKObserverQuery(sampleType: waterType, predicate: nil) { [weak self] _, completion, _ in
+                self?.fetchHydration()
+                completion()
+            }
+            store.execute(query)
+            queries.append(query)
+        }
+        let workoutType = HKObjectType.workoutType()
+        let workoutQuery = HKObserverQuery(sampleType: workoutType, predicate: nil) { [weak self] _, completion, _ in
+            self?.fetchWorkouts()
+            completion()
+        }
+        store.execute(workoutQuery)
+        queries.append(workoutQuery)
+    }
+
+    private func fetchSteps() {
+        guard let type = HKObjectType.quantityType(forIdentifier: .stepCount) else { return }
+        let start = Calendar.current.startOfDay(for: Date())
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: Date(), options: .strictStartDate)
+        let query = HKStatisticsQuery(quantityType: type, quantitySamplePredicate: predicate, options: .cumulativeSum) { [weak self] _, result, _ in
+            DispatchQueue.main.async {
+                self?.stepsToday = result?.sumQuantity()?.doubleValue(for: .count()) ?? 0
+            }
+        }
+        store.execute(query)
+    }
+
+    private func fetchWorkouts() {
+        let type = HKObjectType.workoutType()
+        let query = HKSampleQuery(sampleType: type, predicate: nil, limit: HKObjectQueryNoLimit, sortDescriptors: nil) { [weak self] _, results, _ in
+            DispatchQueue.main.async {
+                self?.workouts = results as? [HKWorkout] ?? []
+            }
+        }
+        store.execute(query)
+    }
+
+    private func fetchSleep() {
+        guard let type = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else { return }
+        let query = HKSampleQuery(sampleType: type, predicate: nil, limit: HKObjectQueryNoLimit, sortDescriptors: nil) { [weak self] _, results, _ in
+            DispatchQueue.main.async {
+                self?.sleep = results as? [HKCategorySample] ?? []
+            }
+        }
+        store.execute(query)
+    }
+
+    private func fetchHydration() {
+        guard let type = HKObjectType.quantityType(forIdentifier: .dietaryWater) else { return }
+        let start = Calendar.current.startOfDay(for: Date())
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: Date(), options: .strictStartDate)
+        let query = HKStatisticsQuery(quantityType: type, quantitySamplePredicate: predicate, options: .cumulativeSum) { [weak self] _, result, _ in
+            DispatchQueue.main.async {
+                self?.hydration = result?.sumQuantity()?.doubleValue(for: .liter()) ?? 0
+            }
+        }
+        store.execute(query)
+    }
+}

--- a/apex/apex/ViewModels/HomeViewModel.swift
+++ b/apex/apex/ViewModels/HomeViewModel.swift
@@ -35,6 +35,7 @@ class HomeViewModel: ObservableObject {
         profile.height = 0
         profile.joinDate = Date()
         profile.accountType = "guest"
+        profile.syncHealthKit = false
         save()
         fetchProfiles()
     }

--- a/apex/apex/ViewModels/OnboardingCoordinator.swift
+++ b/apex/apex/ViewModels/OnboardingCoordinator.swift
@@ -4,7 +4,7 @@ import CoreData
 
 class OnboardingCoordinator: ObservableObject {
     enum Step: Int, CaseIterable {
-        case age, gender, height, weight, goal, activity, dietaryPrefs, glp1, coachPersonality
+        case age, gender, height, weight, goal, activity, dietaryPrefs, glp1, coachPersonality, healthKit
     }
 
     @Published var step: Step
@@ -17,6 +17,7 @@ class OnboardingCoordinator: ObservableObject {
     @Published var dietaryPrefs: String = ""
     @Published var usesGLP1: Bool = false
     @Published var coachPersonality: String = ""
+    @Published var enableHealthKit: Bool = false
     @Published var error: String?
 
     @AppStorage("onboardingStep") private var savedStep: Int = 0
@@ -31,7 +32,7 @@ class OnboardingCoordinator: ObservableObject {
 
     func next() {
         guard validateCurrentStep() else { return }
-        if step == .coachPersonality {
+        if step == .healthKit {
             completeOnboarding()
             return
         }
@@ -67,6 +68,8 @@ class OnboardingCoordinator: ObservableObject {
             break
         case .coachPersonality:
             guard !coachPersonality.isEmpty else { error = "Choose a coach style"; return false }
+        case .healthKit:
+            break
         }
         return true
     }
@@ -91,8 +94,9 @@ class OnboardingCoordinator: ObservableObject {
         profile.usesGLP1 = usesGLP1
         profile.coachPersonality = coachPersonality
         profile.hasCompletedOnboarding = true
-        profile.onboardingStep = Int16(Step.coachPersonality.rawValue)
+        profile.onboardingStep = Int16(Step.healthKit.rawValue)
         profile.accountType = "guest"
+        profile.syncHealthKit = enableHealthKit
         do {
             try stack.saveContext()
             hasCompleted = true

--- a/apex/apex/ViewModels/OnboardingCoordinator.swift
+++ b/apex/apex/ViewModels/OnboardingCoordinator.swift
@@ -69,7 +69,7 @@ class OnboardingCoordinator: ObservableObject {
         case .coachPersonality:
             guard !coachPersonality.isEmpty else { error = "Choose a coach style"; return false }
         case .healthKit:
-            break
+            guard enableHealthKit else { error = "Enable HealthKit to proceed"; return false }
         }
         return true
     }

--- a/apex/apex/Views/OnboardingView.swift
+++ b/apex/apex/Views/OnboardingView.swift
@@ -33,6 +33,9 @@ struct OnboardingView: View {
             case .coachPersonality:
                 CoachPersonalityStepView(coordinator: coordinator)
                     .transition(.slide)
+            case .healthKit:
+                HealthKitStepView(coordinator: coordinator)
+                    .transition(.slide)
             }
         }
         .animation(.easeInOut, value: coordinator.step)
@@ -245,6 +248,26 @@ private struct CoachPersonalityStepView: View {
                 Button("Finish") { coordinator.next() }
                     .buttonStyle(.borderedProminent)
             }
+        }
+    }
+}
+
+private struct HealthKitStepView: View {
+    @ObservedObject var coordinator: OnboardingCoordinator
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Sync with HealthKit?")
+                .font(.title)
+            Text("Apex uses your step, workout, sleep and hydration data to personalize your plan.")
+                .multilineTextAlignment(.center)
+            Toggle("Enable HealthKit Sync", isOn: $coordinator.enableHealthKit)
+            Button("Continue") {
+                if coordinator.enableHealthKit {
+                    HealthKitService.shared.requestAuthorization()
+                }
+                coordinator.next()
+            }
+            .buttonStyle(.borderedProminent)
         }
     }
 }

--- a/apex/apex/Views/ProfileView.swift
+++ b/apex/apex/Views/ProfileView.swift
@@ -42,10 +42,16 @@ struct ProfileView: View {
                         Toggle("Using GLP-1 Medication", isOn: $formData.usesGLP1)
                         TextField("Dietary Preferences", text: $formData.dietaryPreferences)
                         TextField("Coach Personality", text: $formData.coachType)
+                        Toggle("Sync HealthKit", isOn: $formData.syncHealthKit)
                     }
                 }
                 .onAppear {
                     formData = profile.toModel()
+                }
+                .onChange(of: formData.syncHealthKit) { enabled in
+                    if enabled {
+                        HealthKitService.shared.requestAuthorization()
+                    }
                 }
                 Button("Save") {
                     viewModel.updateProfile(with: formData)

--- a/apex/apex/apexApp.swift
+++ b/apex/apex/apexApp.swift
@@ -12,6 +12,7 @@ import CoreData
 struct apexApp: App {
     private let stack = CoreDataStack.shared
     @StateObject private var auth = AuthViewModel()
+    @StateObject private var health = HealthKitService.shared
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     var body: some Scene {
@@ -21,14 +22,17 @@ struct apexApp: App {
                     MainTabView()
                         .environment(\.managedObjectContext, stack.context)
                         .environmentObject(auth)
+                        .environmentObject(health)
                 } else {
                     OnboardingView()
                         .environment(\.managedObjectContext, stack.context)
                         .environmentObject(auth)
+                        .environmentObject(health)
                 }
             } else {
                 SignInView()
                     .environmentObject(auth)
+                    .environmentObject(health)
             }
         }
     }

--- a/apex/apexTests/apexTests.swift
+++ b/apex/apexTests/apexTests.swift
@@ -33,6 +33,7 @@ struct apexTests {
         profile.bodyFatPercentage = 0
         profile.height = 180
         profile.joinDate = Date()
+        profile.syncHealthKit = false
         try context.save()
 
         let fetch = try context.fetch(UserProfile.fetchRequest())


### PR DESCRIPTION
## Summary
- integrate HealthKit via new `HealthKitService`
- add sync toggle in profile settings
- include HealthKit step in onboarding flow
- store user preference in Core Data
- expose service through `apexApp`
- update README capability description

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684d1147ac44832a8b5675993016e5fb