### PR TITLE
Add sync status UI for CloudKit and HealthKit

### DIFF
--- a/apex/apex/Services/SyncService.swift
+++ b/apex/apex/Services/SyncService.swift
@@ -1,0 +1,44 @@
+import Foundation
+import CloudKit
+
+@MainActor
+class SyncService: ObservableObject {
+    static let shared = SyncService()
+    private init() {}
+
+    @Published var cloudKitLastSync: Date?
+    @Published var cloudKitError: String?
+
+    @Published var healthKitLastSync: Date?
+
+    func syncNow() {
+        syncCloudKit()
+        syncHealthKit()
+    }
+
+    func syncCloudKit() {
+        cloudKitError = nil
+        let container = CKContainer.default()
+        print("Starting CloudKit sync")
+        container.privateCloudDatabase.fetchAllRecordZones { [weak self] _, error in
+            Task { @MainActor in
+                if let error = error {
+                    self?.cloudKitError = "Sync failed: Check connection or try again"
+                    print("CloudKit sync failed: \(error.localizedDescription)")
+                } else {
+                    self?.cloudKitLastSync = Date()
+                    print("CloudKit sync succeeded at \(self?.cloudKitLastSync ?? Date())")
+                }
+            }
+        }
+    }
+
+    func syncHealthKit() {
+        if HealthKitService.shared.isAuthorized {
+            print("Starting HealthKit sync")
+            HealthKitService.shared.fetchAll()
+            healthKitLastSync = Date()
+            print("HealthKit sync succeeded at \(healthKitLastSync ?? Date())")
+        }
+    }
+}

--- a/apex/apex/Views/ProfileView.swift
+++ b/apex/apex/Views/ProfileView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @EnvironmentObject var auth: AuthViewModel
+    @EnvironmentObject var sync: SyncService
     @StateObject private var viewModel = ProfileViewModel()
     @State private var formData = UserProfileModel()
     @State private var showUpgrade = false
@@ -58,6 +59,9 @@ struct ProfileView: View {
                 }
                 .buttonStyle(.borderedProminent)
 
+                SyncStatusView()
+                    .environmentObject(sync)
+
                 if auth.isGuest {
                     Button("Upgrade Account") {
                         showUpgrade = true
@@ -80,4 +84,5 @@ struct ProfileView: View {
     ProfileView()
         .environment(\.managedObjectContext, CoreDataStack.shared.context)
         .environmentObject(AuthViewModel())
+        .environmentObject(SyncService.shared)
 }

--- a/apex/apex/Views/SyncStatusView.swift
+++ b/apex/apex/Views/SyncStatusView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct SyncStatusView: View {
+    @EnvironmentObject var sync: SyncService
+
+    private var cloudKitStatusText: String {
+        if let error = sync.cloudKitError {
+            return error
+        }
+        if let date = sync.cloudKitLastSync {
+            return "Last synced \(date.formatted())"
+        }
+        return "Never synced"
+    }
+
+    private var healthKitStatusText: String {
+        if !HealthKitService.shared.isAuthorized {
+            return "Off"
+        }
+        if let date = sync.healthKitLastSync {
+            return "Last synced \(date.formatted())"
+        }
+        return "On"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("CloudKit", systemImage: "icloud")
+                Spacer()
+                Text(cloudKitStatusText)
+                    .foregroundStyle(sync.cloudKitError == nil ? .primary : .red)
+                    .multilineTextAlignment(.trailing)
+            }
+            HStack {
+                Label("HealthKit", systemImage: "heart.fill")
+                Spacer()
+                Text(healthKitStatusText)
+                    .multilineTextAlignment(.trailing)
+            }
+            Button("Sync Now") {
+                sync.syncNow()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+#Preview {
+    SyncStatusView()
+        .environmentObject(SyncService.shared)
+}

--- a/apex/apex/apexApp.swift
+++ b/apex/apex/apexApp.swift
@@ -13,6 +13,7 @@ struct apexApp: App {
     private let stack = CoreDataStack.shared
     @StateObject private var auth = AuthViewModel()
     @StateObject private var health = HealthKitService.shared
+    @StateObject private var sync = SyncService.shared
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     var body: some Scene {
@@ -23,16 +24,19 @@ struct apexApp: App {
                         .environment(\.managedObjectContext, stack.context)
                         .environmentObject(auth)
                         .environmentObject(health)
+                        .environmentObject(sync)
                 } else {
                     OnboardingView()
                         .environment(\.managedObjectContext, stack.context)
                         .environmentObject(auth)
                         .environmentObject(health)
+                        .environmentObject(sync)
                 }
             } else {
                 SignInView()
                     .environmentObject(auth)
                     .environmentObject(health)
+                    .environmentObject(sync)
             }
         }
     }


### PR DESCRIPTION
## Summary
- create `SyncService` to track CloudKit and HealthKit syncs
- add `SyncStatusView` with friendly status messages and `Sync Now` button
- embed sync view in Profile and wire up SyncService across the app

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d134b5fb8832a82fff953bbe638e1