### PR TITLE
Fix Info.plist path in Xcode project

### DIFF
--- a/apex/apex.xcodeproj/project.pbxproj
+++ b/apex/apex.xcodeproj/project.pbxproj
@@ -400,7 +400,7 @@
 				DEVELOPMENT_TEAM = GYM2RX99U4;
 				ENABLE_PREVIEWS = YES;
                                CODE_SIGN_ENTITLEMENTS = apex.entitlements;
-                               INFOPLIST_FILE = apex/Info.plist;
+                               INFOPLIST_FILE = Info.plist;
                                LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -427,7 +427,7 @@
 				DEVELOPMENT_TEAM = GYM2RX99U4;
 				ENABLE_PREVIEWS = YES;
                                CODE_SIGN_ENTITLEMENTS = apex.entitlements;
-                               INFOPLIST_FILE = apex/Info.plist;
+                               INFOPLIST_FILE = Info.plist;
                                LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
- fix Info.plist path for Debug and Release configurations

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -workspace apex/apex.xcodeproj/project.xcworkspace -scheme apex -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2e60814c832aa919e75122ce6479