### PR TITLE
Add Amplify deployment workflow

### DIFF
--- a/.github/workflows/amplify.yml
+++ b/.github/workflows/amplify.yml
@@ -1,0 +1,27 @@
+name: Deploy to Amplify
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, macos]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: Install Amplify CLI
+        run: npm install -g @aws-amplify/cli
+      - name: Pull Amplify backend
+        run: amplify pull --appId ${{ secrets.AMPLIFY_APP_ID }} --envName ${{ secrets.AMPLIFY_ENV }} --yes
+      - name: Publish to Amplify
+        run: amplify publish --yes


### PR DESCRIPTION
## Summary
- add workflow for AWS Amplify deployment on self-hosted runner

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f4233ffd4832a9479eafb9cdcea3e